### PR TITLE
Preliminary user data structure/model

### DIFF
--- a/frontend/src/lib/models/Fact.ts
+++ b/frontend/src/lib/models/Fact.ts
@@ -1,0 +1,4 @@
+export interface Fact {
+    factName: string;
+    factContent: string;
+}

--- a/frontend/src/lib/models/Post.ts
+++ b/frontend/src/lib/models/Post.ts
@@ -1,0 +1,3 @@
+export interface Post {
+    // TO BE IMPLEMENTED
+}

--- a/frontend/src/lib/models/User.ts
+++ b/frontend/src/lib/models/User.ts
@@ -1,4 +1,5 @@
 import { Post } from "./Post.ts"
+import { Fact } from "./Fact.ts"
 
 export interface User {
     userId: string // user_id, unique to account, public
@@ -16,7 +17,7 @@ export interface User {
         receiveEmailNotifications: boolean; // for authored posts, posts commented on, mentions/replies
     };
     profileContent: {
-        about: string[]; // user-input facts (e.g., *Favorite Study Spot:* SEL)
+        about: Fact[]; // user-input facts (e.g., *Favorite Study Spot:* SEL)
         blurb: string; 
         courses: string;
     }

--- a/frontend/src/lib/models/User.ts
+++ b/frontend/src/lib/models/User.ts
@@ -1,0 +1,25 @@
+import { Post } from "./Post.ts"
+
+export interface User {
+    userId: string // user_id, unique to account, public
+    name: string; // display name, public
+    email: string; // private/hashed
+    password: string; // private/hashed
+    
+    pronouns: string; // private, only displayed if enabled in settings
+    iconContent: string; // inner text for user icon
+
+    settings: {
+        displayPronouns: boolean;
+        displayMajor: boolean;
+        
+        receiveEmailNotifications: boolean; // for authored posts, posts commented on, mentions/replies
+    };
+    profileContent: {
+        about: string[]; // user-input facts (e.g., *Favorite Study Spot:* SEL)
+        blurb: string; 
+        courses: string;
+    }
+
+    authoredPosts: Post[];
+  }


### PR DESCRIPTION
Set up an initial data structure/model for the user profile, so we have something similar to work with, if necessary for UI implementation (off the top of my head, user data is needed for user profile & settings pages, comments, posts). Any changes to attributes can made on each branch & we can work out inconsistencies as they come up.

I also initialized an interface for posts, but only so I didn't have an error with the list of posts linked to the user. It'd probably be better for someone working with implementing the post screens to handle the attributes for those; I didn't want to mess anything up.