### PR TITLE
Important edit to BaseComponent.js loadCSS()

### DIFF
--- a/frontend/src/components/BaseComponent/BaseComponent.js
+++ b/frontend/src/components/BaseComponent/BaseComponent.js
@@ -24,7 +24,8 @@ export class BaseComponent {
       const link = document.createElement('link');
       link.rel = 'stylesheet';
       // Dynamically load CSS from the same directory as the JS file
-      link.href = `../components/${fileName}/${fileName}.css`; // EDIT FROM CLASS EXAMPLE: adjust file path for compatibility with our folder structure      document.head.appendChild(link);
+      link.href = `../components/${fileName}/${fileName}.css`; // EDIT FROM CLASS EXAMPLE: adjust file path for compatibility with our folder structure
+      document.head.appendChild(link);
       this.cssLoaded = true;
     }
   

--- a/frontend/src/components/BaseComponent/BaseComponent.js
+++ b/frontend/src/components/BaseComponent/BaseComponent.js
@@ -24,8 +24,7 @@ export class BaseComponent {
       const link = document.createElement('link');
       link.rel = 'stylesheet';
       // Dynamically load CSS from the same directory as the JS file
-      link.href = `./components/${fileName}/${fileName}.css`;
-      document.head.appendChild(link);
+      link.href = `../components/${fileName}/${fileName}.css`; // EDIT FROM CLASS EXAMPLE: adjust file path for compatibility with our folder structure      document.head.appendChild(link);
       this.cssLoaded = true;
     }
   


### PR DESCRIPTION
Small edit to loadCSS, adjusted file path to work with our folder structure. loadCSS() won't load the correct CSS file with original file path (doesn't escape enough folder levels up).

link.href = ``./components/${fileName}/${fileName}.css`` changed to ``../../components/${fileName}/${fileName}.css``