### PR TITLE
Crowding report modal

### DIFF
--- a/frontend/src/components/LocationBrowsingComponent/LocationBrowsingComponent.css
+++ b/frontend/src/components/LocationBrowsingComponent/LocationBrowsingComponent.css
@@ -4,3 +4,101 @@
     grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
     gap: 1rem;
 }
+
+/**** report modal ****/
+#report-modal { /* note: same styling as location card, for now */
+    background: var(--grey-100);
+    box-shadow: var(--grey-400) 0 1px 3px;
+
+    z-index: 1000; /* bring to top (higher than expanded card, if overlap occurs) */
+    position: absolute;
+
+    height: fit-content;
+    padding: 1em;
+    border-radius: 10px;
+    max-width: 15rem;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center
+}
+
+#report-modal button {
+    font-size: 1rem;
+    width: 100%;
+    margin: 0.25rem 0;
+
+    /* generally the same as other buttons */
+    box-sizing: border-box;
+    padding: 0.25rem 0.5rem;
+    border-radius: 10rem;
+
+    color: var(--grey-500);
+    font-weight: 600;
+}
+
+#report-modal button:hover {
+    cursor: pointer;
+}
+
+button#report-submit {
+    width: fit-content;
+    background: var(--navbar-purple);
+    border: 1px solid var(--navbar-purple);
+}
+
+button#report-submit:hover {
+    border: 1px solid var(--grey-300);
+    background: var(--grey-300);
+}
+
+button#level1 {
+    background: var(--light-green);
+    border: 1px solid var(--light-green);
+}
+
+button#level1:hover {
+    color: black;
+    background: var(--bright-green)
+}
+
+button#level2 {
+    background: var(--light-blue);
+    border: 1px solid var(--light-blue);
+}
+
+button#level2:hover {
+    color: black;
+    background: var(--bright-blue);
+}
+
+button#level3 {
+    background: var(--light-yellow);
+    border: 1px solid var(--light-yellow);
+}
+
+button#level3:hover {
+    color: black;
+    background: var(--bright-yellow);
+}
+
+button#level4 {
+    background: var(--light-orange);
+    border: 1px solid var(--light-orange);
+}
+
+button#level4:hover {
+    color: black;
+    background: var(--bright-yellow);
+}
+
+button#level5 {
+    background: var(--light-red);
+    border: 1px solid var(--light-red);
+}
+
+button#level5:hover {
+    color: black;
+    background: var(--bright-red);
+}

--- a/frontend/src/components/LocationBrowsingComponent/LocationBrowsingComponent.js
+++ b/frontend/src/components/LocationBrowsingComponent/LocationBrowsingComponent.js
@@ -217,7 +217,7 @@ export class LocationBrowsingComponent extends BaseComponent {
             this.#hideElement(this.#dimmerElement); // hide dimmer element when a card is minimized/returned to normal view
         })
 
-        // alert eventhub to minimize expanded card view if area outside of card (i.e., dimmer element) is clicked
+        // alert event hub to minimize expanded card view if area outside of card (i.e., dimmer element) is clicked
         this.#dimmerElement.addEventListener("click", () => {
             hub.publish(Events.MinimizeLocationCard); // minimize expanded location card if clicked
         })
@@ -232,11 +232,33 @@ export class LocationBrowsingComponent extends BaseComponent {
         const sortByElement = document.getElementById("sort-by-select");
         sortByElement.addEventListener("change", (event) => this.#sortLocationCards(event.target.value)); // update on changed selection
 
-        // attach event listener to open report modal
+        // subscribe event listener to open report modal
         hub.subscribe(Events.OpenReportModal, (data) => {
             this.#showElement(this.#reportModal); // open report modal
             document.getElementById("report-location-name").innerText = data;
-            
         });
+        
+        // close report modal if area outside modal is clicked
+        document.addEventListener("click", (event) => {
+            if (this.#reportModal.style.display !== "none" && !this.#reportModal.contains(event.target)) {
+                // ref for .contains() usage: https://johnsonkow.medium.com/event-listener-for-outside-click-75226f5c8ce0
+                this.#hideElement(this.#reportModal);
+                console.log("clicked outside")
+            }
+        })
+
+        // attach event listener for Escape key press
+        // if report modal is open, minimize
+        // otherwise, minimize card (still check if card is in expanded card view)
+        document.addEventListener("keyup", (event) => {
+            if (event.code === "Escape") { // escape key press
+                if (this.#reportModal.style.display !== "none") { // report modal visible
+                    this.#hideElement(this.#reportModal); // minimize report modal
+                    event.stopPropagation(); // shouldn't matter, but just to be safe
+                } else if (document.querySelector(".expanded") !== undefined) { // otherwise, escape expanded card if applicable
+                    hub.publish(Events.MinimizeLocationCard); // minimize expanded card (via event hub subscription)
+                }
+            }
+        })
     }
 }

--- a/frontend/src/components/LocationCardComponent/LocationCardComponent.js
+++ b/frontend/src/components/LocationCardComponent/LocationCardComponent.js
@@ -150,21 +150,6 @@ export class LocationCardComponent extends BaseComponent {
         this.#container.classList.add("expanded");        
         // display minimize button, address, report buttons (all previously"hidden" elements)
         this.#container.querySelectorAll(".show-on-expand").forEach(element => {element.style.display = "inline-block"});
-        
-        // TODO: move this elsewhere to avoid duplicate function creation
-        // attach event listeners for reporting crowding score (on button click)
-        this.#container.querySelectorAll(".report-button") // get each report button
-            .forEach(button => button.addEventListener('click', (event) => {
-                const hub = EventHub.getInstance();
-                hub.publish(Events.OpenReportModal, this.#locationData.name);
-                event.stopPropagation();
-                // TODO: implement location crowding score reporting
-                // TODO: determine if saving user-id is necessary for location report...
-                // if (event.target.classList.values().some(className => className.includes("floor"))) { // TODO: clean up this conditional...
-                //    console.log(event.target.classList[1]); // get floor name
-                // }
-                // console.log(`report for ${this.#locationData.name} ${event.target.}`);
-            }));
     }
 
     // reset expanded card
@@ -210,5 +195,19 @@ export class LocationCardComponent extends BaseComponent {
                 hub.publish(Events.MinimizeLocationCard);
             }
         });
+
+        // attach necessary event listeners for reporting crowding score (on "Report Crowding" button click)
+        this.#container.querySelectorAll(".report-button") // get each report button
+            .forEach(button => button.addEventListener('click', (event) => {
+                const hub = EventHub.getInstance(); // get event hub
+                // if multi-floor, attach floor that the clicked report button corresponds with
+                const buttonClassList = button.classList.value.split(" "); // string array of class tags
+                const floor = this.#locationData.type === "Single-Floor" ? null : buttonClassList[1]; // get corresponding floor name if multi-floor
+                const data = { name: this.#locationData.name, floor: floor}; // data to send to report modal
+                hub.publish(Events.OpenReportModal, data); // alert event hub
+
+                // prevent bubble up
+                event.stopPropagation(); // not really necessary, but just in case
+            }));
     }
 }

--- a/frontend/src/components/LocationCardComponent/LocationCardComponent.js
+++ b/frontend/src/components/LocationCardComponent/LocationCardComponent.js
@@ -155,6 +155,8 @@ export class LocationCardComponent extends BaseComponent {
         // attach event listeners for reporting crowding score (on button click)
         this.#container.querySelectorAll(".report-button") // get each report button
             .forEach(button => button.addEventListener('click', (event) => {
+                const hub = EventHub.getInstance();
+                hub.publish(Events.OpenReportModal, this.#locationData.name);
                 // TODO: implement location crowding score reporting
                 // TODO: determine if saving user-id is necessary for location report...
                 // if (event.target.classList.values().some(className => className.includes("floor"))) { // TODO: clean up this conditional...

--- a/frontend/src/components/LocationCardComponent/LocationCardComponent.js
+++ b/frontend/src/components/LocationCardComponent/LocationCardComponent.js
@@ -157,6 +157,7 @@ export class LocationCardComponent extends BaseComponent {
             .forEach(button => button.addEventListener('click', (event) => {
                 const hub = EventHub.getInstance();
                 hub.publish(Events.OpenReportModal, this.#locationData.name);
+                event.stopPropagation();
                 // TODO: implement location crowding score reporting
                 // TODO: determine if saving user-id is necessary for location report...
                 // if (event.target.classList.values().some(className => className.includes("floor"))) { // TODO: clean up this conditional...
@@ -206,16 +207,6 @@ export class LocationCardComponent extends BaseComponent {
                 this.#minimizeExpandedCard(); // call minimize method only if card is expanded
                 
                 // update eventhub for minimizing location card -> this affects dimmer element in LocationBrowsingComponent
-                hub.publish(Events.MinimizeLocationCard);
-            }
-        });
-
-        // attach event listener to minimize expanded card view on escape key press
-        document.addEventListener('keyup', (event) => {
-            if ((event.code === "Escape") && (this.#container.classList.contains("expanded"))){
-                this.#minimizeExpandedCard();
-
-                // update eventhub for minimizing location card -> this affects dimmer element
                 hub.publish(Events.MinimizeLocationCard);
             }
         });

--- a/frontend/src/eventhub/Events.js
+++ b/frontend/src/eventhub/Events.js
@@ -46,6 +46,8 @@ export const Events = {
 
     // Location Browsing
     ExpandLocationCard: `ExpandLocationCard`,
-    MinimizeLocationCard: `MinimizeLocationCard`
+    MinimizeLocationCard: `MinimizeLocationCard`,
+
+    AddReport: `AddReport`
 }
   


### PR DESCRIPTION
- Implemented UI for crowding score report modal, with event listeners for opening & closing via click and/or Escape key press. 
  - "How crowded is...?" content corresponds with location clicked 
- Implemented event listener for storing crowding level selection to local storage and first half of report submission functionality.
  - Upon clicking any of the crowding level buttons in the expanded modal, the selection is stored locally with the key "crowding"
  - Closing the report modal clears this selection from local storage
  - Clicking the "Submit" button -> checks if a selection is made before publishing AddReport to eventhub for the backend to handle

**TODO:**
- Next step is to wrap up backend implementation (work in progress), but I need to merge what I have on this branch to make things a bit easier on the branch for #69.
- I'll likely add some additional styling to the buttons after finishing backend functionality, so the selected level is also indicated to the user.

<img src="https://github.com/user-attachments/assets/c5d58374-0f2b-4196-a4b4-0d9b61f18152" width=250>